### PR TITLE
when trying to upload to LOV the following error found

### DIFF
--- a/Ontologies/decomp.owl
+++ b/Ontologies/decomp.owl
@@ -29,7 +29,7 @@
      xmlns:vs="http://www.w3.org/2003/06/sw-vocab-status/ns#">
     <Ontology rdf:about="http://www.w3.org/ns/lemon/decomp">
         <rdf:type rdf:resource="http://purl.org/vocommons/voaf#Vocabulary"/>
-        <versionInfo rdf:datatype="&xsd;decimal">1.0.1</versionInfo>
+        <versionInfo rdf:datatype="&xsd;decimal">1.1</versionInfo>
         <dc:issued rdf:datatype="&xsd;date">2016-01-10</dc:issued>
         <dc:modified rdf:datatype="&xsd;date">2016-01-10</dc:modified>
         <dc:rights>CC-Zero</dc:rights>
@@ -54,7 +54,7 @@
         <cc:licence rdf:resource="https://creativecommons.org/publicdomain/zero/1.0/"/>
         <dc:contributor rdf:resource="https://sites.google.com/site/francescafrontini/"/>
         <rdfs:comment xml:lang="en">-Version 1.0: depreciation with minor change in metadata for LOV publication
--Version 1.0.1: creation</rdfs:comment>
+-Version 1.1: creation</rdfs:comment>
     </Ontology>
     
 

--- a/Ontologies/lime.owl
+++ b/Ontologies/lime.owl
@@ -32,7 +32,7 @@
     <owl:Ontology rdf:about="http://www.w3.org/ns/lemon/lime">
         <rdf:type rdf:resource="http://purl.org/vocommons/voaf#Vocabulary"/>
         <rdfs:label xml:lang="en">Lexicon Model for Ontologies - LIngusitic MEtadata (LIME)</rdfs:label>
-        <owl:versionInfo rdf:datatype="&xsd;decimal">1.0.1</owl:versionInfo>
+        <owl:versionInfo rdf:datatype="&xsd;decimal">1.1</owl:versionInfo>
         <dc:modified rdf:datatype="&xsd;date">2016-01-10</dc:modified>
         <dc:issued rdf:datatype="&xsd;date">2016-01-10</dc:issued>
         <vann:preferredNamespaceUri rdf:datatype="&xsd;string">http://www.w3.org/ns/lemon/lime#</vann:preferredNamespaceUri>
@@ -57,7 +57,7 @@
         <cc:licence rdf:resource="https://creativecommons.org/publicdomain/zero/1.0/"/>
         <dc:contributor rdf:resource="https://sites.google.com/site/francescafrontini/"/>
         <rdfs:comment xml:lang="en">-Version 1.0: depreciation with minor change in metadata for LOV publication
--Version 1.0.1: creation</rdfs:comment>
+-Version 1.1: creation</rdfs:comment>
     </owl:Ontology>
     
 

--- a/Ontologies/ontolex.owl
+++ b/Ontologies/ontolex.owl
@@ -33,7 +33,7 @@
      xmlns:vs="http://www.w3.org/2003/06/sw-vocab-status/ns#">
     <owl:Ontology rdf:about="http://www.w3.org/ns/lemon/ontolex">
         <rdf:type rdf:resource="http://purl.org/vocommons/voaf#Vocabulary"/>
-        <owl:versionInfo rdf:datatype="&xsd;decimal">1.1</owl:versionInfo>
+        <owl:versionInfo rdf:datatype="&xsd;decimal">1.0.1</owl:versionInfo>
         <dc:modified rdf:datatype="&xsd;date">2016-01-10</dc:modified>
         <dc:issued rdf:datatype="&xsd;date">2016-01-10</dc:issued>
         <vann:preferredNamespacePrefix>ontolex</vann:preferredNamespacePrefix>
@@ -57,7 +57,7 @@
         <cc:licence rdf:resource="https://creativecommons.org/publicdomain/zero/1.0/"/>
         <dc:contributor rdf:resource="https://sites.google.com/site/francescafrontini/"/>
         <rdfs:comment xml:lang="en">-Version 1.0: depreciation with minor change in metadata for LOV publication
--Version 1.1: creation</rdfs:comment>
+-Version 1.0.1: creation</rdfs:comment>
     </owl:Ontology>
     
 

--- a/Ontologies/ontolex.owl
+++ b/Ontologies/ontolex.owl
@@ -33,7 +33,7 @@
      xmlns:vs="http://www.w3.org/2003/06/sw-vocab-status/ns#">
     <owl:Ontology rdf:about="http://www.w3.org/ns/lemon/ontolex">
         <rdf:type rdf:resource="http://purl.org/vocommons/voaf#Vocabulary"/>
-        <owl:versionInfo rdf:datatype="&xsd;decimal">1.0.1</owl:versionInfo>
+        <owl:versionInfo rdf:datatype="&xsd;decimal">1.1</owl:versionInfo>
         <dc:modified rdf:datatype="&xsd;date">2016-01-10</dc:modified>
         <dc:issued rdf:datatype="&xsd;date">2016-01-10</dc:issued>
         <vann:preferredNamespacePrefix>ontolex</vann:preferredNamespacePrefix>
@@ -57,7 +57,7 @@
         <cc:licence rdf:resource="https://creativecommons.org/publicdomain/zero/1.0/"/>
         <dc:contributor rdf:resource="https://sites.google.com/site/francescafrontini/"/>
         <rdfs:comment xml:lang="en">-Version 1.0: depreciation with minor change in metadata for LOV publication
--Version 1.0.1: creation</rdfs:comment>
+-Version 1.1: creation</rdfs:comment>
     </owl:Ontology>
     
 

--- a/Ontologies/synsem.owl
+++ b/Ontologies/synsem.owl
@@ -33,7 +33,7 @@
      xmlns:vs="http://www.w3.org/2003/06/sw-vocab-status/ns#">
     <owl:Ontology rdf:about="http://www.w3.org/ns/lemon/synsem">
         <rdf:type rdf:resource="http://purl.org/vocommons/voaf#Vocabulary"/>
-        <owl:versionInfo rdf:datatype="&xsd;decimal">1.0.1</owl:versionInfo>
+        <owl:versionInfo rdf:datatype="&xsd;decimal">1.1</owl:versionInfo>
         <dc:modified rdf:datatype="&xsd;date">2016-01-10</dc:modified>
         <dc:issued rdf:datatype="&xsd;date">2016-01-10</dc:issued>
         <dc:description xml:lang="en">A model for the representation of lexical information relative to ontologies. Syntax and semantics module.</dc:description>
@@ -58,7 +58,7 @@
         <cc:licence rdf:resource="https://creativecommons.org/publicdomain/zero/1.0/"/>
         <dc:contributor rdf:resource="https://sites.google.com/site/francescafrontini/"/>
         <rdfs:comment xml:lang="en">-Version 1.0: depreciation with minor change in metadata for LOV publication
--Version 1.0.1: creation</rdfs:comment>
+-Version 1.1: creation</rdfs:comment>
     </owl:Ontology>
     
 

--- a/Ontologies/vartrans.owl
+++ b/Ontologies/vartrans.owl
@@ -31,7 +31,7 @@
      xmlns:vs="http://www.w3.org/2003/06/sw-vocab-status/ns#">
     <owl:Ontology rdf:about="http://www.w3.org/ns/lemon/vartrans">
         <rdf:type rdf:resource="http://purl.org/vocommons/voaf#Vocabulary"/>
-        <versionInfo rdf:datatype="&xsd;decimal">1.0.1</versionInfo>
+        <versionInfo rdf:datatype="&xsd;decimal">1.1</versionInfo>
         <dc:issued rdf:datatype="&xsd;date">2016-01-10</dc:issued>
         <dc:modified rdf:datatype="&xsd;date">2016-01-10</dc:modified>
         <dc:rights>CC-Zero</dc:rights>
@@ -57,7 +57,7 @@
         <cc:licence rdf:resource="https://creativecommons.org/publicdomain/zero/1.0/"/>
         <dc:contributor rdf:resource="https://sites.google.com/site/francescafrontini/"/>
         <rdfs:comment xml:lang="en">-Version 1.0: depreciation with minor change in metadata for LOV publication
--Version 1.0.1: creation</rdfs:comment>
+-Version 1.1: creation</rdfs:comment>
     </owl:Ontology>
     
     <owl:AnnotationProperty rdf:about="&vs;term_status"/>


### PR DESCRIPTION
When trying to upload to LOV the following error found:

WARN Lexical form '1.0.1' not valid for datatype http://www.w3.org/2001/XMLSchema#decimal WARN Datatype format exception: "1.0.1"^^xsd:decimal WARN Datatype format exception: "1.0.1"^^xsd:decimal

Version number as per guideline is 
<owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">1.1</owl:versionInfo> 
guideline link can be found here
https://lov.linkeddata.es/Recommendations_Vocabulary_Design.pdf

The version number is changed to 1.1
