### PR TITLE
deleting two license statement and keeping correct one

### DIFF
--- a/Ontologies/decomp.owl
+++ b/Ontologies/decomp.owl
@@ -51,7 +51,6 @@
         <dc:publisher rdf:resource="http://www.w3.org/community/ontolex"/>
         <imports rdf:resource="http://www.w3.org/ns/lemon/ontolex"/>
         <cc:license rdf:resource="https://creativecommons.org/publicdomain/zero/1.0/"/>
-        <cc:licence rdf:resource="https://creativecommons.org/publicdomain/zero/1.0/"/>
         <dc:contributor rdf:resource="https://sites.google.com/site/francescafrontini/"/>
         <rdfs:comment xml:lang="en">-Version 1.0: depreciation with minor change in metadata for LOV publication
 -Version 1.1: creation</rdfs:comment>

--- a/Ontologies/lime.owl
+++ b/Ontologies/lime.owl
@@ -54,7 +54,6 @@
         <dc:publisher rdf:resource="http://www.w3.org/community/ontolex"/>
         <owl:imports rdf:resource="http://www.w3.org/ns/lemon/ontolex"/>
         <cc:license rdf:resource="https://creativecommons.org/publicdomain/zero/1.0/"/>
-        <cc:licence rdf:resource="https://creativecommons.org/publicdomain/zero/1.0/"/>
         <dc:contributor rdf:resource="https://sites.google.com/site/francescafrontini/"/>
         <rdfs:comment xml:lang="en">-Version 1.0: depreciation with minor change in metadata for LOV publication
 -Version 1.1: creation</rdfs:comment>

--- a/Ontologies/ontolex.owl
+++ b/Ontologies/ontolex.owl
@@ -54,7 +54,6 @@
         <dc:contributor rdf:resource="http://www.paulbuitelaar.net/"/>
         <dc:publisher rdf:resource="http://www.w3.org/community/ontolex"/>
         <cc:license rdf:resource="https://creativecommons.org/publicdomain/zero/1.0/"/>
-        <cc:licence rdf:resource="https://creativecommons.org/publicdomain/zero/1.0/"/>
         <dc:contributor rdf:resource="https://sites.google.com/site/francescafrontini/"/>
         <rdfs:comment xml:lang="en">-Version 1.0: depreciation with minor change in metadata for LOV publication
 -Version 1.1: creation</rdfs:comment>

--- a/Ontologies/synsem.owl
+++ b/Ontologies/synsem.owl
@@ -55,7 +55,6 @@
         <dc:publisher rdf:resource="http://www.w3.org/community/ontolex"/>
         <owl:imports rdf:resource="http://www.w3.org/ns/lemon/ontolex"/>
         <cc:license rdf:resource="https://creativecommons.org/publicdomain/zero/1.0/"/>
-        <cc:licence rdf:resource="https://creativecommons.org/publicdomain/zero/1.0/"/>
         <dc:contributor rdf:resource="https://sites.google.com/site/francescafrontini/"/>
         <rdfs:comment xml:lang="en">-Version 1.0: depreciation with minor change in metadata for LOV publication
 -Version 1.1: creation</rdfs:comment>

--- a/Ontologies/vartrans.owl
+++ b/Ontologies/vartrans.owl
@@ -54,7 +54,6 @@
         <imports rdf:resource="http://www.w3.org/ns/lemon/ontolex"/>
         <owl:imports rdf:resource="http://www.w3.org/ns/lemon/ontolex"/>
         <cc:license rdf:resource="https://creativecommons.org/publicdomain/zero/1.0/"/>
-        <cc:licence rdf:resource="https://creativecommons.org/publicdomain/zero/1.0/"/>
         <dc:contributor rdf:resource="https://sites.google.com/site/francescafrontini/"/>
         <rdfs:comment xml:lang="en">-Version 1.0: depreciation with minor change in metadata for LOV publication
 -Version 1.1: creation</rdfs:comment>


### PR DESCRIPTION
There is two license statement. I have deleted one.
The Metadata guideline of LOV suggests "licence" which is wrong. It is found during submission to LOV.
In this pull request, it is corrected.  

The change also needs to be made in W3C files (with the latest version in the GIT)