### PR TITLE
Corrected typo in phthisis example of vartrans module.

### DIFF
--- a/Examples/vartrans/example4.ttl
+++ b/Examples/vartrans/example4.ttl
@@ -18,7 +18,7 @@
 
 :phthisis_form ontolex:writtenRep "phthisis"@en .
 
-:phtisis_sense ontolex:reference <http://dbpedia.org/resource/Tuberculosis>;
+:phthisis_sense ontolex:reference <http://dbpedia.org/resource/Tuberculosis>;
                dct:subject <http://dbpedia.org/resource/Medicine> .
 
 :phtisis_diachronic_relation a vartrans:TerminologicalRelation ;

--- a/Examples/vartrans/example5.ttl
+++ b/Examples/vartrans/example5.ttl
@@ -11,13 +11,13 @@
 :surrogate_mother_sense ontolex:isLexicalizedSenseOf ontology:SurrogateMother .
 
 :madre_de_alquiler a ontolex:LexicalEntry;
-      dct:language <http://id.loc.gov/vocabulary/iso639-2/es>, <http://lexvo.org/id/iso639-1/es> ;
+      dct:language <http://id.loc.gov/vocabulary/iso639-2/spa>, <http://lexvo.org/id/iso639-1/es> ;
       ontolex:sense :madre_de_alquiler_sense.
 
 :madre_de_alquiler_sense ontolex:isLexicalizedSenseOf ontology:SurrogateMother .
 
 :leihmutter a ontolex:LexicalEntry;
-      dct:language <http://id.loc.gov/vocabulary/iso639-2/de>, <http://lexvo.org/id/iso639-1/de> ;
+      dct:language <http://id.loc.gov/vocabulary/iso639-2/deu>, <http://lexvo.org/id/iso639-1/de> ;
       ontolex:sense :leihmutter_sense.
 
 :leihmutter_sense ontolex:isLexicalizedSenseOf ontology:SurrogateMother .

--- a/Examples/vartrans/example6.ttl
+++ b/Examples/vartrans/example6.ttl
@@ -10,7 +10,7 @@
 :zip_code_sense ontolex:reference <http://dbpedia.org/ontology/zipCode>.
 
 :postleitzahl a ontolex:LexicalEntry;
-      dct:language <http://id.loc.gov/vocabulary/iso639-2/de>, <http://lexvo.org/id/iso639-1/de> ;
+      dct:language <http://id.loc.gov/vocabulary/iso639-2/deu>, <http://lexvo.org/id/iso639-1/de> ;
       ontolex:sense :postleitzahl_sense.
 
 :postleitzahl_sense ontolex:reference <http://de.dbpedia.org/resource/Postleitzahl>.

--- a/Examples/vartrans/example7.ttl
+++ b/Examples/vartrans/example7.ttl
@@ -10,7 +10,7 @@
 :zip_code_sense ontolex:reference <http://dbpedia.org/ontology/zipCode>.
 
 :postleitzahl a ontolex:LexicalEntry;
-      dct:language <http://id.loc.gov/vocabulary/iso639-2/de>, <http://lexvo.org/id/iso639-1/de> ;
+      dct:language <http://id.loc.gov/vocabulary/iso639-2/deu>, <http://lexvo.org/id/iso639-1/de> ;
       ontolex:sense :postleitzahl_sense.
 
 :postleitzahl_sense ontolex:reference <http://de.dbpedia.org/resource/Postleitzahl>.

--- a/Examples/vartrans/example8.ttl
+++ b/Examples/vartrans/example8.ttl
@@ -7,10 +7,10 @@
       dct:language <http://id.loc.gov/vocabulary/iso639-2/eng>, <http://lexvo.org/id/iso639-1/en> .
  
 :rincón a ontolex:LexicalEntry;
-       dct:language <http://id.loc.gov/vocabulary/iso639-2/es>, <http://lexvo.org/id/iso639-1/es> .
+       dct:language <http://id.loc.gov/vocabulary/iso639-2/spa>, <http://lexvo.org/id/iso639-1/es> .
 
 :esquina a ontolex:LexicalEntry;
-       dct:language <http://id.loc.gov/vocabulary/iso639-2/es>, <http://lexvo.org/id/iso639-1/es> .
+       dct:language <http://id.loc.gov/vocabulary/iso639-2/spa>, <http://lexvo.org/id/iso639-1/es> .
 
 :corner vartrans:translatableAs :rincón.
 :corner vartrans:translatableAs :esquina.


### PR DESCRIPTION
Coorected a typo in phtisis example that led to a incorrectly structured graph.
Fixed the language codes as specified in id.loc.gov vocabulary and used in several examples.