### PR TITLE
corrected Durchschnittliche Ambiguität for german

### DIFF
--- a/Ontologies/lime.owl
+++ b/Ontologies/lime.owl
@@ -325,7 +325,7 @@
     <!-- http://www.w3.org/ns/lemon/lime#avgAmbiguity -->
 
     <owl:DatatypeProperty rdf:about="http://www.w3.org/ns/lemon/lime#avgAmbiguity">
-        <rdfs:label xml:lang="de">Durchschnittliche Amiguität</rdfs:label>
+        <rdfs:label xml:lang="de">Durchschnittliche Ambiguität</rdfs:label>
         <rdfs:label xml:lang="en">average ambiguity</rdfs:label>
         <rdfs:label xml:lang="es">ambigüedad promedia</rdfs:label>
         <rdfs:label xml:lang="fr">ambiguïté moyenne</rdfs:label>


### PR DESCRIPTION
    <rdfs:label xml:lang="de">Durchschnittliche Amiguität</rdfs:label>`

There is a typo in the German label. It should be

    <rdfs:label xml:lang="de">Durchschnittliche Ambiguität</rdfs:label